### PR TITLE
Fix % encoding bug at end of string

### DIFF
--- a/core/src/main/scala/rl/UrlCodingUtils.scala
+++ b/core/src/main/scala/rl/UrlCodingUtils.scala
@@ -87,7 +87,7 @@ trait UrlCodingUtils {
             in.position(mark+1)
           }
         } else {
-          in.position(in.position() - 1)
+          out.put('%'.toByte)
         }
       } else if (c == '+' && plusIsSpace) {
         out.put(' '.toByte)

--- a/core/src/test/scala/rl/tests/UrlCodingSpec.scala
+++ b/core/src/test/scala/rl/tests/UrlCodingSpec.scala
@@ -36,6 +36,11 @@ class UrlCodingSpec extends Specification {
       "decode a pct encoded string" ! {
         urlDecode("hello%20world") must_== "hello world"
       } ^
+      "gracefully handle '%' encoding errors" ! {
+        urlDecode("%") must_== "%"
+        urlDecode("%2") must_== "%2"
+        urlDecode("%20") must_== " "
+      } ^
       "decode value consisting of 2 values to 1 char" ! {
         urlDecode("%C3%A9") must_== "é"
       } ^


### PR DESCRIPTION
Fix endless loop if the urlDecode method is called with a string that ends with a '%' without two following chars.
